### PR TITLE
set default bpm

### DIFF
--- a/util/Midi/MIDI.gd
+++ b/util/Midi/MIDI.gd
@@ -74,7 +74,7 @@ enum SystemExclusiveStatus {
 # Vars
 var tracks = []
 export var tempo = 0
-export var bpm = 0
+export var bpm = 120
 export var ppq = 0.0
 
 


### PR DESCRIPTION
some MIDI files don't set bpm. so when calculating ticks per second divison by zero occurs